### PR TITLE
[PKG-3014] jinjasql2 0.1.11 :snowflake:

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+upload_channels:
+  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ test:
   commands:
     - pip check
     # testcontainers is required by https://github.com/pythonutilities/jinjasql/blob/0.1.11/tests/__init__.py#L4
-    # but we skip test_real_database.py that require it
+    # but we skip testing test_real_database.py
     - pip install testcontainers
     # Ignore test_real_database.py because the conda main channel doesn't have the testcontainers package
     # and we aren't able to run docker containers with PostrgeSQL and MySQL


### PR DESCRIPTION
Changelog: https://github.com/pythonutilities/jinjasql/releases
License: https://github.com/pythonutilities/jinjasql/blob/0.1.11/LICENSE
Requirements: https://github.com/pythonutilities/jinjasql/blob/0.1.11/setup.py

Actions:
1. Create a brand new feedstock
2. Add a test suite

Notes:
- `jinjasql` is no longer maintained, see https://github.com/sripathikrishnan/jinjasql/issues/50#issuecomment-1657230029, but the fork `jinjasql2` is actively maintained (see https://github.com/pythonutilities/jinjasql) and we build `jinjasql2`